### PR TITLE
Fix Spacy version to be < 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ pip install --upgrade pip
 pip install numpy==1.16.2
 pip install gym==0.15.4
 pip install textworld
-pip install -U spacy
+pip install -U "spacy<3"
 python -m spacy download en
 pip install tqdm pipreqs h5py pyyaml visdom
 conda install pytorch torchvision cudatoolkit=9.2 -c pytorch

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy==1.16.2
 gym==0.15.4
 h5py==2.10.0
 textworld
-spacy
+spacy<3
 tqdm
 pipreqs
 pyyaml


### PR DESCRIPTION
For sake of reproducibility, I'm going to restrict Spacy's version to be < 3.0.0 since we haven't tested the code with Spacy 3+. 